### PR TITLE
Add endpoint to get stock by product

### DIFF
--- a/mkmsdk/api_map.py
+++ b/mkmsdk/api_map.py
@@ -522,6 +522,11 @@ _API_MAP = {
                     "method": "put",
                     "description": "Decrease articles' quantities in authenticated user's stock",
                 },
+                "get_product_stock": {
+                    "url": "/stock/products/{product}",
+                    "method": "get",
+                    "description": "Returns all articles in the authenticated user's stock for a specified product",
+                },
             },
             "wants_list": {
                 "get_all_wants_list": {


### PR DESCRIPTION
Cardmarket introduced new endpoint to get User's stock by product ID

https://api.cardmarket.com/ws/documentation/API_2.0:Export_Articles_Of_Product

Endpoint to search User's stock by product name has some limitations and doesn't work well for Basic Lands and Tokens

Thanks for maintaining 😸 
